### PR TITLE
Develop 0.2.4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,3 +106,17 @@ jobs:
     - run: |
         kubectl apply -n ${{ secrets.KUBERNETES_CLUSTER_NAMESPACE }} -f bin/ci/service.yml && \
         kubectl apply -n ${{ secrets.KUBERNETES_CLUSTER_NAMESPACE }} -f bin/ci/deployment-v2.yml
+    - run: |
+        kubectl apply -n ${{ secrets.KUBERNETES_CLUSTER_NAMESPACE }} -f bin/ci/service.yml && \
+        kubectl apply -n ${{ secrets.KUBERNETES_CLUSTER_NAMESPACE }} -f bin/ci/deployment-v2.yml
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      with:
+        tag_name: $(node -e 'console.log(require("./package").version)')
+        release_name: $(node -e 'console.log(require("./package").version)')
+        body: $(git log -1 --pretty=%B)
+        draft: false
+        prerelease: false

--- a/bin/controller.keys.js
+++ b/bin/controller.keys.js
@@ -27,6 +27,8 @@ var _ = require('lodash');
 
 module.exports.updateKeys = function updateKeys(options, taskCallback) {
 
+    let roles = process.env.ALLOW_SSH_ACCESS_ROLES || "admin,maintain,write";
+
     taskCallback = 'function' === typeof taskCallback ? taskCallback : function taskCallback() {
 
         if (process.env.SLACK_NOTIFICACTION_URL && process.env.SLACK_NOTIFICACTION_URL.indexOf("https") === 0) {
@@ -178,7 +180,7 @@ module.exports.updateKeys = function updateKeys(options, taskCallback) {
                         // get just the permissions, add users to application
                         ('object' === typeof body && body.length > 0 ? body : []).forEach(function(thisUser) {
                             // provide access only for users with roles: `maintain` and `admin`
-                            if (thisUser.role_name == 'maintain' || thisUser.role_name == 'admin') {
+                            if (_.includes(_.split(roles, ","), thisUser.role_name)) {
                                 _applications[data.sshUser].users[thisUser.login] = {
                                     _id: thisUser.login,
                                     permissions: thisUser.permissions

--- a/changes.md
+++ b/changes.md
@@ -1,6 +1,7 @@
 
 ### 0.2.4
 * Added an option to set roles by `ALLOW_SSH_ACCESS_ROLES` env. Set `admin`, `maintain`, `write` by default.
+* Added the action to create a GitHub release.
 
 ### 0.2.3
 * Prevent access to `production` containers.

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,7 @@
+
+### 0.2.4
+* Added an option to set roles by `ALLOW_SSH_ACCESS_ROLES` env. Set `admin`, `maintain`, `write` by default.
+
 ### 0.2.3
 * Prevent access to `production` containers.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "docker-sftp",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "description": "SSH tunnels to containers",
     "main": "bin/server.js",
     "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,8 @@ Run for debug:
 docker-compose up --build --renew-anon-volumes
 ```
 
+You can control an access to containers by adding `ALLOW_SSH_ACCESS_ROLES` env(str). Set roles through coma you want to grant an access. `admin`, `maintain`, `write` by default.
+
 ### Secrets
 * GKE_PROJECT - GCP project ID
 * GKE_SA_KEY - GCP SA key(json)


### PR DESCRIPTION
### 0.2.4
* Added an option to set roles by `ALLOW_SSH_ACCESS_ROLES` env. Set `admin`, `maintain`, `write` by default.
* Added the action to create a GitHub release.
