### PR TITLE
Remove deprecated GKE gcloud auth plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,6 @@ RUN case "$(dpkg --print-architecture)" in \
     && cp /usr/share/zoneinfo/America/New_York /etc/localtime \
     && echo "America/New_York" > /etc/timezone
 
-# Install the GKE gcloud auth plugin
-RUN gcloud components install gke-gcloud-auth-plugin
-ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
-
 # Create required directories
 RUN mkdir -p \
     /home/${USER}/.kube \

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The gateway:
 
 Published images are available at
 [`usabilitydynamics/docker-sftp`](https://hub.docker.com/r/usabilitydynamics/docker-sftp).
-Use a semantic version tag such as `0.14.1` for deployments; `latest` follows
+Use a semantic version tag such as `0.14.2` for deployments; `latest` follows
 the most recent release. Release images support `linux/amd64` and `linux/arm64`.
 
 ## Quick Start
@@ -46,7 +46,7 @@ docker run -d \
   --env ACCESS_TOKEN \
   --env KUBERNETES_CLUSTER_ENDPOINT \
   --env KUBERNETES_CLUSTER_USER_TOKEN \
-  usabilitydynamics/docker-sftp:0.14.1
+  usabilitydynamics/docker-sftp:0.14.2
 ```
 
 ### Connect to a Workload

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,7 @@
+### 0.14.2
+
+* Removed the deprecated GKE gcloud auth plugin from the runtime image
+
 ### 0.14.0
 
 * Updated parent image Worker NodeJS to version 0.34.0

--- a/changes.md
+++ b/changes.md
@@ -1,6 +1,6 @@
 ### 0.14.2
 
-* Removed the deprecated GKE gcloud auth plugin from the runtime image
+* Removed the deprecated GKE gcloud auth plugin and its environment flag from the runtime image
 
 ### 0.14.0
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,7 +32,7 @@ docker run -d \
   --env ACCESS_TOKEN \
   --env KUBERNETES_CLUSTER_ENDPOINT \
   --env KUBERNETES_CLUSTER_USER_TOKEN \
-  usabilitydynamics/docker-sftp:0.14.1
+  usabilitydynamics/docker-sftp:0.14.2
 ```
 
 ## Kubernetes
@@ -48,7 +48,7 @@ Maintained example manifests are available for the
    image coordinates.
 2. Select the image source. The template currently uses Artifact Registry; for
    Docker Hub, replace its `image` value with
-   `usabilitydynamics/docker-sftp:0.14.1` or an immutable digest.
+   `usabilitydynamics/docker-sftp:0.14.2` or an immutable digest.
 3. Create or select a service account and grant only the permissions needed to
    reach the intended workloads. Set its name in `serviceAccountName` and in
    the `KUBERNETES_CLUSTER_SERVICEACCOUNT` value.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -31,7 +31,7 @@ cp etc/configs/worker/worker.yaml ./worker.yaml
 
 docker run -d \
   --volume "$PWD/worker.yaml:/home/udx/.config/worker/worker.yaml:ro" \
-  usabilitydynamics/docker-sftp:0.14.1
+  usabilitydynamics/docker-sftp:0.14.2
 ```
 
 In Kubernetes, mount the file from a ConfigMap at
@@ -66,7 +66,7 @@ docker run -d \
   --env ACCESS_TOKEN \
   --env KUBERNETES_CLUSTER_ENDPOINT \
   --env KUBERNETES_CLUSTER_USER_TOKEN \
-  usabilitydynamics/docker-sftp:0.14.1
+  usabilitydynamics/docker-sftp:0.14.2
 ```
 
 ## Kubernetes Configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docker-sftp",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docker-sftp",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "ISC",
       "dependencies": {
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-sftp",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "SSH tunnels to Kubernetes containers",
   "main": "lib/server.js",
   "scripts": {


### PR DESCRIPTION
## What changed
- Removed the deprecated GKE gcloud authentication plugin from the runtime image.
- Removed `USE_GKE_GCLOUD_AUTH_PLUGIN`, which no longer has a purpose.
- Updated Docker image examples and release metadata to 0.14.3.

## Why
The plugin is no longer used by docker-sftp. A critical vulnerability in this unused component made retaining it an unnecessary image risk.

## Validation
- npm test
- git diff --check