### PR TITLE
Run SSH commands through a shell in the target container

### DIFF
--- a/bin/controller.ssh.entrypoint.sh
+++ b/bin/controller.ssh.entrypoint.sh
@@ -53,12 +53,12 @@ if [[ "x${SSH_ORIGINAL_COMMAND}" != "x" ]]; then
     echo "[$(date)] Have SSH session using command: [kubectl exec -n $CONNECTION_STRING -ti -- ${SSH_ORIGINAL_COMMAND})] for [${USER}] from [${API_REQUEST_URL}]." >> /var/log/sshd.log
   fi
 
-  ##/usr/local/bin/kubectl exec ${_SERVICE} -ti -- "${SSH_ORIGINAL_COMMAND}"
-  __commad="/usr/local/bin/kubectl exec -n $CONNECTION_STRING -i -- $SSH_ORIGINAL_COMMAND"
-  
-  echo $__commad >> /var/log/sshd.log
+  ## Run the command through a shell inside the container so quoting, cd,
+  ## &&, pipes and redirects behave like standard sshd. CONNECTION_STRING
+  ## stays unquoted on purpose - it expands to "<namespace> pods/<pod>".
+  echo "/usr/local/bin/kubectl exec -n $CONNECTION_STRING -i -- /bin/sh -c <command>" >> /var/log/sshd.log
 
-  $__commad;
+  /usr/local/bin/kubectl exec -n $CONNECTION_STRING -i -- /bin/sh -c "$SSH_ORIGINAL_COMMAND"
 
 fi;
 
@@ -83,11 +83,10 @@ if [[ "x${SSH_ORIGINAL_COMMAND}" == "x" ]]; then
   ## Log screen size.
   echo "[$(date)] Container [${USER}] has [${_COLUMNS}] columns and [${_ROWS}] rows." >> /var/log/sshd.log
 
-  _command="/usr/local/bin/kubectl exec -n $CONNECTION_STRING -ti -- /bin/bash"
+  ## Prefer bash, fall back to sh for containers without bash (e.g. Alpine).
+  echo "/usr/local/bin/kubectl exec -n $CONNECTION_STRING -ti -- sh -c 'exec bash || exec sh'" >> /var/log/sshd.log
 
-  echo $_command >> /var/log/sshd.log
-
-  $_command;
+  /usr/local/bin/kubectl exec -n $CONNECTION_STRING -ti -- /bin/sh -c "command -v bash >/dev/null 2>&1 && exec bash -l || exec sh -l"
 
 fi;
 

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,8 @@
+### 0.14.2
+
+* Run SSH commands through `/bin/sh -c` inside the target container so quoting, `cd`, `&&`, pipes, and redirects behave like standard sshd
+* Interactive sessions now fall back to `sh` when the container has no `bash` (e.g. Alpine images)
+
 ### 0.14.0
 
 * Updated parent image Worker NodeJS to version 0.34.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docker-sftp",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docker-sftp",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "ISC",
       "dependencies": {
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-sftp",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "SSH tunnels to Kubernetes containers",
   "main": "lib/server.js",
   "scripts": {


### PR DESCRIPTION
## Problem

The ForceCommand entrypoint passed `SSH_ORIGINAL_COMMAND` word-split directly to `kubectl exec`, so the first token was exec'd as a raw binary inside the pod. `cd`, `&&`, pipes, redirects, and any quoting broke:

```
$ ssh -T <env>@ssh.rabbit.ci "cd /var/www && git status"
OCI runtime exec failed: exec: "cd": executable file not found in $PATH
```

Clients had to scp scripts into containers to run anything non-trivial.

## Fix

Wrap the command in `/bin/sh -c`, matching standard sshd behavior:

```bash
kubectl exec -n $CONNECTION_STRING -i -- /bin/sh -c "$SSH_ORIGINAL_COMMAND"
```

Interactive sessions now prefer `bash` but fall back to `sh` for containers without bash (e.g. Alpine images).

## Verified

Patched the running gateway pod in place and tested against www.udx.io staging/production containers:
- `cd /var/www && git status` (compound commands, cwd)
- quoting and pipes: `echo 'quotes "work" too' | tr a-z A-Z`
- plain wp-cli commands (backward compat)
- scp round-trip
- interactive shell session

Releases 0.14.2.