### PR TITLE
Release 0.14.4 security updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,29 @@
-FROM usabilitydynamics/udx-worker-nodejs:0.34.0
+ARG KUBECTL_VERSION=1.36.2
+ARG KUBECTL_X_NET_VERSION=0.55.0
 
-ENV KUBECTL_VERSION=1.36.2 \
+FROM golang:1.26.0-bookworm AS kubectl-builder
+
+ARG KUBECTL_VERSION
+ARG KUBECTL_X_NET_VERSION
+
+RUN git clone --depth 1 --branch "v${KUBECTL_VERSION}" \
+        https://github.com/kubernetes/kubernetes.git /src/kubernetes \
+    && cd /src/kubernetes \
+    && go mod edit -require="golang.org/x/net@v${KUBECTL_X_NET_VERSION}" \
+    && KUBECTL_GIT_COMMIT="$(git rev-parse HEAD)" \
+    && KUBECTL_MAJOR="${KUBECTL_VERSION%%.*}" \
+    && KUBECTL_MINOR="${KUBECTL_VERSION#*.}" \
+    && KUBECTL_MINOR="${KUBECTL_MINOR%%.*}" \
+    && KUBECTL_LDFLAGS="-X k8s.io/client-go/pkg/version.gitVersion=v${KUBECTL_VERSION} -X k8s.io/client-go/pkg/version.gitCommit=${KUBECTL_GIT_COMMIT} -X k8s.io/client-go/pkg/version.gitTreeState=clean -X k8s.io/client-go/pkg/version.gitMajor=${KUBECTL_MAJOR} -X k8s.io/client-go/pkg/version.gitMinor=${KUBECTL_MINOR} -X k8s.io/component-base/version.gitVersion=v${KUBECTL_VERSION} -X k8s.io/component-base/version.gitCommit=${KUBECTL_GIT_COMMIT} -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.gitMajor=${KUBECTL_MAJOR} -X k8s.io/component-base/version.gitMinor=${KUBECTL_MINOR}" \
+    && GOWORK=off GOFLAGS=-mod=mod go build -trimpath -ldflags="${KUBECTL_LDFLAGS}" -o /out/kubectl ./cmd/kubectl
+
+FROM usabilitydynamics/udx-worker-nodejs:0.35.0
+
+ARG KUBECTL_VERSION
+ARG KUBECTL_X_NET_VERSION
+
+ENV KUBECTL_VERSION=${KUBECTL_VERSION} \
+    KUBECTL_X_NET_VERSION=${KUBECTL_X_NET_VERSION} \
     NODE_ENV=production \
     APP_HOME=/opt/sources/rabbitci/rabbit-ssh
 
@@ -23,22 +46,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Install the Kubernetes 1.36.2 client with the fixed golang.org/x/net dependency.
+COPY --from=kubectl-builder /out/kubectl /usr/local/bin/kubectl
+
 # Setup kubectl and timezone
-RUN case "$(dpkg --print-architecture)" in \
-        amd64) ARCH="amd64" ;; \
-        arm64) ARCH="arm64" ;; \
-        armhf) ARCH="arm" ;; \
-        i386) ARCH="386" ;; \
-        ppc64el) ARCH="ppc64le" ;; \
-        s390x) ARCH="s390x" ;; \
-        *) echo "Unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
-    esac \
-    && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" \
-    && curl -fsSLo /tmp/kubectl.sha256 "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256" \
-    && echo "$(cat /tmp/kubectl.sha256)  /usr/local/bin/kubectl" | sha256sum --check \
-    && chmod +x /usr/local/bin/kubectl \
+RUN chmod +x /usr/local/bin/kubectl \
     && kubectl version --client \
-    && rm -f /tmp/kubectl.sha256 \
     && rm -rf /etc/ssh/* \
     && mkdir -p /etc/ssh/authorized_keys.d \
     && cp /usr/share/zoneinfo/America/New_York /etc/localtime \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,10 @@
 ARG KUBECTL_VERSION=1.36.2
-ARG KUBECTL_X_NET_VERSION=0.55.0
-
-FROM golang:1.26.0-bookworm AS kubectl-builder
-
-ARG KUBECTL_VERSION
-ARG KUBECTL_X_NET_VERSION
-
-RUN git clone --depth 1 --branch "v${KUBECTL_VERSION}" \
-        https://github.com/kubernetes/kubernetes.git /src/kubernetes \
-    && cd /src/kubernetes \
-    && go mod edit -require="golang.org/x/net@v${KUBECTL_X_NET_VERSION}" \
-    && KUBECTL_GIT_COMMIT="$(git rev-parse HEAD)" \
-    && KUBECTL_MAJOR="${KUBECTL_VERSION%%.*}" \
-    && KUBECTL_MINOR="${KUBECTL_VERSION#*.}" \
-    && KUBECTL_MINOR="${KUBECTL_MINOR%%.*}" \
-    && KUBECTL_LDFLAGS="-X k8s.io/client-go/pkg/version.gitVersion=v${KUBECTL_VERSION} -X k8s.io/client-go/pkg/version.gitCommit=${KUBECTL_GIT_COMMIT} -X k8s.io/client-go/pkg/version.gitTreeState=clean -X k8s.io/client-go/pkg/version.gitMajor=${KUBECTL_MAJOR} -X k8s.io/client-go/pkg/version.gitMinor=${KUBECTL_MINOR} -X k8s.io/component-base/version.gitVersion=v${KUBECTL_VERSION} -X k8s.io/component-base/version.gitCommit=${KUBECTL_GIT_COMMIT} -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.gitMajor=${KUBECTL_MAJOR} -X k8s.io/component-base/version.gitMinor=${KUBECTL_MINOR}" \
-    && GOWORK=off GOFLAGS=-mod=mod go build -trimpath -ldflags="${KUBECTL_LDFLAGS}" -o /out/kubectl ./cmd/kubectl
 
 FROM usabilitydynamics/udx-worker-nodejs:0.35.0
 
 ARG KUBECTL_VERSION
-ARG KUBECTL_X_NET_VERSION
 
 ENV KUBECTL_VERSION=${KUBECTL_VERSION} \
-    KUBECTL_X_NET_VERSION=${KUBECTL_X_NET_VERSION} \
     NODE_ENV=production \
     APP_HOME=/opt/sources/rabbitci/rabbit-ssh
 
@@ -46,12 +27,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Install the Kubernetes 1.36.2 client with the fixed golang.org/x/net dependency.
-COPY --from=kubectl-builder /out/kubectl /usr/local/bin/kubectl
-
 # Setup kubectl and timezone
-RUN chmod +x /usr/local/bin/kubectl \
+RUN case "$(dpkg --print-architecture)" in \
+        amd64) ARCH="amd64" ;; \
+        arm64) ARCH="arm64" ;; \
+        armhf) ARCH="arm" ;; \
+        i386) ARCH="386" ;; \
+        ppc64el) ARCH="ppc64le" ;; \
+        s390x) ARCH="s390x" ;; \
+        *) echo "Unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" \
+    && curl -fsSLo /tmp/kubectl.sha256 "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256" \
+    && echo "$(cat /tmp/kubectl.sha256)  /usr/local/bin/kubectl" | sha256sum --check \
+    && chmod +x /usr/local/bin/kubectl \
     && kubectl version --client \
+    && rm -f /tmp/kubectl.sha256 \
     && rm -rf /etc/ssh/* \
     && mkdir -p /etc/ssh/authorized_keys.d \
     && cp /usr/share/zoneinfo/America/New_York /etc/localtime \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
-ARG KUBECTL_VERSION=1.36.2
-
 FROM usabilitydynamics/udx-worker-nodejs:0.35.0
 
-ARG KUBECTL_VERSION
-
-ENV KUBECTL_VERSION=${KUBECTL_VERSION} \
+ENV KUBECTL_VERSION=1.36.2 \
     NODE_ENV=production \
     APP_HOME=/opt/sources/rabbitci/rabbit-ssh
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The gateway:
 
 Published images are available at
 [`usabilitydynamics/docker-sftp`](https://hub.docker.com/r/usabilitydynamics/docker-sftp).
-Use a semantic version tag such as `0.14.4` for deployments; `latest` follows
-the most recent release. Release images support `linux/amd64` and `linux/arm64`.
+Use `latest` for local testing. Pin a semantic version tag or immutable digest
+for deployments. Release images support `linux/amd64` and `linux/arm64`.
 
 ## Quick Start
 
@@ -46,7 +46,7 @@ docker run -d \
   --env ACCESS_TOKEN \
   --env KUBERNETES_CLUSTER_ENDPOINT \
   --env KUBERNETES_CLUSTER_USER_TOKEN \
-  usabilitydynamics/docker-sftp:0.14.4
+  usabilitydynamics/docker-sftp:latest
 ```
 
 ### Connect to a Workload

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The gateway:
 
 Published images are available at
 [`usabilitydynamics/docker-sftp`](https://hub.docker.com/r/usabilitydynamics/docker-sftp).
-Use a semantic version tag such as `0.14.3` for deployments; `latest` follows
+Use a semantic version tag such as `0.14.4` for deployments; `latest` follows
 the most recent release. Release images support `linux/amd64` and `linux/arm64`.
 
 ## Quick Start
@@ -46,7 +46,7 @@ docker run -d \
   --env ACCESS_TOKEN \
   --env KUBERNETES_CLUSTER_ENDPOINT \
   --env KUBERNETES_CLUSTER_USER_TOKEN \
-  usabilitydynamics/docker-sftp:0.14.3
+  usabilitydynamics/docker-sftp:0.14.4
 ```
 
 ### Connect to a Workload

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,8 @@
+### 0.14.4
+
+* Updated parent image Worker NodeJS to version 0.35.0, including the patched npm `tar` dependency
+* Rebuilt `kubectl` 1.36.2 with `golang.org/x/net` 0.55.0 to address CVE-2026-39821 before an upstream Kubernetes patch release is available
+
 ### 0.14.3
 
 * Removed the deprecated GKE gcloud auth plugin and its environment flag from the runtime image

--- a/changes.md
+++ b/changes.md
@@ -1,7 +1,6 @@
 ### 0.14.4
 
 * Updated parent image Worker NodeJS to version 0.35.0, including the patched npm `tar` dependency
-* Rebuilt `kubectl` 1.36.2 with `golang.org/x/net` 0.55.0 to address CVE-2026-39821 before an upstream Kubernetes patch release is available
 
 ### 0.14.3
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,7 +32,7 @@ docker run -d \
   --env ACCESS_TOKEN \
   --env KUBERNETES_CLUSTER_ENDPOINT \
   --env KUBERNETES_CLUSTER_USER_TOKEN \
-  usabilitydynamics/docker-sftp:0.14.4
+  usabilitydynamics/docker-sftp:latest
 ```
 
 ## Kubernetes
@@ -47,8 +47,8 @@ Maintained example manifests are available for the
    service-account name, service-account token, certificate, access token, and
    image coordinates.
 2. Select the image source. The template currently uses Artifact Registry; for
-   Docker Hub, replace its `image` value with
-   `usabilitydynamics/docker-sftp:0.14.4` or an immutable digest.
+   Docker Hub, use `usabilitydynamics/docker-sftp:latest` while testing, then
+   pin a semantic version tag or immutable digest for deployment.
 3. Create or select a service account and grant only the permissions needed to
    reach the intended workloads. Set its name in `serviceAccountName` and in
    the `KUBERNETES_CLUSTER_SERVICEACCOUNT` value.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,7 +32,7 @@ docker run -d \
   --env ACCESS_TOKEN \
   --env KUBERNETES_CLUSTER_ENDPOINT \
   --env KUBERNETES_CLUSTER_USER_TOKEN \
-  usabilitydynamics/docker-sftp:0.14.3
+  usabilitydynamics/docker-sftp:0.14.4
 ```
 
 ## Kubernetes
@@ -48,7 +48,7 @@ Maintained example manifests are available for the
    image coordinates.
 2. Select the image source. The template currently uses Artifact Registry; for
    Docker Hub, replace its `image` value with
-   `usabilitydynamics/docker-sftp:0.14.3` or an immutable digest.
+   `usabilitydynamics/docker-sftp:0.14.4` or an immutable digest.
 3. Create or select a service account and grant only the permissions needed to
    reach the intended workloads. Set its name in `serviceAccountName` and in
    the `KUBERNETES_CLUSTER_SERVICEACCOUNT` value.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -31,7 +31,7 @@ cp etc/configs/worker/worker.yaml ./worker.yaml
 
 docker run -d \
   --volume "$PWD/worker.yaml:/home/udx/.config/worker/worker.yaml:ro" \
-  usabilitydynamics/docker-sftp:0.14.4
+  usabilitydynamics/docker-sftp:latest
 ```
 
 In Kubernetes, mount the file from a ConfigMap at
@@ -66,7 +66,7 @@ docker run -d \
   --env ACCESS_TOKEN \
   --env KUBERNETES_CLUSTER_ENDPOINT \
   --env KUBERNETES_CLUSTER_USER_TOKEN \
-  usabilitydynamics/docker-sftp:0.14.4
+  usabilitydynamics/docker-sftp:latest
 ```
 
 ## Kubernetes Configuration

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -31,7 +31,7 @@ cp etc/configs/worker/worker.yaml ./worker.yaml
 
 docker run -d \
   --volume "$PWD/worker.yaml:/home/udx/.config/worker/worker.yaml:ro" \
-  usabilitydynamics/docker-sftp:0.14.3
+  usabilitydynamics/docker-sftp:0.14.4
 ```
 
 In Kubernetes, mount the file from a ConfigMap at
@@ -66,7 +66,7 @@ docker run -d \
   --env ACCESS_TOKEN \
   --env KUBERNETES_CLUSTER_ENDPOINT \
   --env KUBERNETES_CLUSTER_USER_TOKEN \
-  usabilitydynamics/docker-sftp:0.14.3
+  usabilitydynamics/docker-sftp:0.14.4
 ```
 
 ## Kubernetes Configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docker-sftp",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docker-sftp",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "license": "ISC",
       "dependencies": {
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-sftp",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "SSH tunnels to Kubernetes containers",
   "main": "lib/server.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Update the Worker NodeJS base image to 0.35.0, including the patched npm tar dependency.

## Scope
- Changed: runtime base image, release version, and deployment references.
- Not changed: gateway behavior, Kubernetes client version, or the checksum-verified upstream kubectl download path.

## Remaining security follow-up
- The upstream kubectl 1.36.2 binary remains unchanged. Kubernetes has not published a newer release yet; its reported critical finding will be handled by a small version-bump follow-up when that patch is available.

## Validation
- npm test (10 passing)
- Docker build and image vulnerability scan are running in CI because the local Docker daemon is unavailable.