### PR TITLE
Automate Docker dependency upgrades

### DIFF
--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -1,0 +1,585 @@
+---
+name: udx-automation / docker-sftp dependency upgrade
+
+"on":
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  DOCKERFILE: Dockerfile
+  PROBE_DOCKERFILE: .tmp/dependency-probe/Dockerfile
+  REPORT_PATH: docker-dependency-report.json
+  UPDATE_BRANCH: udx-docker-sftp-dependency-updates
+  PR_TITLE: "chore(deps): docker dependency upgrade"
+  PR_TEAM_REVIEWER: devops
+  PR_LABELS: |-
+    docker
+    dependencies
+  PR_AUTO_MERGE: "false"
+  PR_MERGE_METHOD: squash
+  COMMIT_MESSAGE: "chore(deps): update Docker dependency pins"
+  UPLOAD_COPILOT_SESSION: "false"
+  COPILOT_PROMPT_PARTS: >-
+    ci/prompts/docker-dependency-guardrails.md
+    ci/prompts/docker-dependency-apt.md
+    ci/prompts/docker-dependency-nonapt.md
+    ci/prompts/docker-dependency-output.md
+
+jobs:
+  config:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      dockerfile: ${{ steps.config.outputs.dockerfile }}
+      existing_pr_found: ${{ steps.existing-pr.outputs.found }}
+      image: ${{ steps.config.outputs.image }}
+      prompt_parts: ${{ steps.config.outputs.prompt_parts }}
+      probe_dockerfile: ${{ steps.config.outputs.probe_dockerfile }}
+      report_path: ${{ steps.config.outputs.report_path }}
+      update_branch: ${{ steps.config.outputs.update_branch }}
+      pr_title: ${{ steps.config.outputs.pr_title }}
+      pr_auto_merge: ${{ steps.config.outputs.pr_auto_merge }}
+      pr_merge_method: ${{ steps.config.outputs.pr_merge_method }}
+      commit_message: ${{ steps.config.outputs.commit_message }}
+      upload_copilot_session: ${{ steps.config.outputs.upload_copilot_session }}
+      should_run: ${{ steps.decision.outputs.should_run }}
+      skip_reason: ${{ steps.decision.outputs.skip_reason }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Load dependency updater defaults
+        id: config
+        run: |
+          set -euo pipefail
+
+          {
+            echo "image=docker-sftp-deps-probe:${GITHUB_RUN_ID}"
+            echo "dockerfile=${DOCKERFILE}"
+            echo "prompt_parts=${COPILOT_PROMPT_PARTS}"
+            echo "probe_dockerfile=${PROBE_DOCKERFILE}"
+            echo "report_path=${REPORT_PATH}"
+            echo "update_branch=${UPDATE_BRANCH}"
+            echo "pr_title=${PR_TITLE}"
+            echo "pr_auto_merge=${PR_AUTO_MERGE}"
+            echo "pr_merge_method=${PR_MERGE_METHOD}"
+            echo "commit_message=${COMMIT_MESSAGE}"
+            echo "upload_copilot_session=${UPLOAD_COPILOT_SESSION}"
+          } >> "${GITHUB_OUTPUT}"
+
+          test -n "${DOCKERFILE}"
+          test -n "${COPILOT_PROMPT_PARTS}"
+          test -n "${PROBE_DOCKERFILE}"
+          test -n "${UPLOAD_COPILOT_SESSION}"
+          test -f "${DOCKERFILE}"
+          for prompt_part in ${COPILOT_PROMPT_PARTS}; do
+            test -s "${prompt_part}"
+          done
+          echo "Dependency updater defaults loaded for ${DOCKERFILE}"
+
+      - name: Stop if an update PR is already open
+        id: existing-pr
+        uses: actions/github-script@v9
+        env:
+          UPDATE_BRANCH: ${{ steps.config.outputs.update_branch }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = `${owner}:${process.env.UPDATE_BRANCH}`;
+
+            const prs = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: "open",
+              head,
+              per_page: 100
+            });
+
+            core.setOutput("found", prs.data.length > 0 ? "true" : "false");
+            if (prs.data.length > 0) {
+              console.log(`Update PR already open: ${prs.data[0].html_url}`);
+            } else {
+              console.log(`No open update PR found for ${head}`);
+            }
+
+      - name: Decide updater execution
+        id: decision
+        run: |
+          set -euo pipefail
+
+          if [ "${EXISTING_PR_FOUND}" = "true" ]; then
+            echo "should_run=false" >> "${GITHUB_OUTPUT}"
+            echo "skip_reason=Update PR already open for ${UPDATE_BRANCH}" \
+              >> "${GITHUB_OUTPUT}"
+            echo "Config decision: skip; update PR already open."
+            exit 0
+          fi
+
+          echo "should_run=true" >> "${GITHUB_OUTPUT}"
+          echo "skip_reason=" >> "${GITHUB_OUTPUT}"
+          echo "Config decision: run upgrade; no open updater PR found."
+        env:
+          EXISTING_PR_FOUND: ${{ steps.existing-pr.outputs.found }}
+          UPDATE_BRANCH: ${{ steps.config.outputs.update_branch }}
+
+  upgrade:
+    needs: config
+    if: needs.config.outputs.should_run == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    outputs:
+      apt_count: ${{ steps.probe.outputs.apt_count }}
+      changed: ${{ steps.changes.outputs.changed }}
+      pr_url: ${{ steps.create-pr.outputs.pull-request-url }}
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Generate dependency probe report
+        id: probe
+        timeout-minutes: 8
+        env:
+          DOCKERFILE: ${{ needs.config.outputs.dockerfile }}
+          PROBE_DOCKERFILE: ${{ needs.config.outputs.probe_dockerfile }}
+          PROBE_IMAGE: ${{ needs.config.outputs.image }}
+          PROBE_REPORT: ${{ needs.config.outputs.report_path }}
+        run: |
+          set -euo pipefail
+
+          probe_dir="$(dirname "${PROBE_DOCKERFILE}")"
+          apt_packages_path="${probe_dir}/apt-packages.txt"
+          apt_versions_path="${probe_dir}/apt.tsv"
+
+          mkdir -p "${probe_dir}"
+
+          awk '
+            {
+              line = $0
+              starts_install = line ~ /apt-get install/
+              if (starts_install) {
+                in_apt = 1
+              }
+              if (in_apt) {
+                gsub(/=("[^"]*"|[^[:space:]\\]+)/, "", line)
+              }
+              print line
+
+              if (in_apt) {
+                remainder = line
+                if (starts_install) {
+                  sub(/^.*apt-get install/, "", remainder)
+                }
+                if (remainder ~ /&&/) {
+                  in_apt = 0
+                }
+              }
+            }
+          ' "${DOCKERFILE}" > "${PROBE_DOCKERFILE}"
+
+          awk '
+            {
+              line = $0
+              starts_install = line ~ /apt-get install/
+              if (starts_install) {
+                in_apt = 1
+                sub(/^.*apt-get install/, "", line)
+              }
+
+              if (in_apt) {
+                sub(/#.*/, "", line)
+                gsub(/\\/, "", line)
+                while (match(line, /[[:alnum:].+-]+=[^[:space:]&\\]+/)) {
+                  package = substr(line, RSTART, RLENGTH)
+                  sub(/=.*/, "", package)
+                  print package
+                  line = substr(line, RSTART + RLENGTH)
+                }
+                if (line ~ /&&/) {
+                  in_apt = 0
+                }
+              }
+            }
+          ' "${DOCKERFILE}" | sort -u > "${apt_packages_path}"
+
+          mapfile -t apt_packages < "${apt_packages_path}"
+          if [ "${#apt_packages[@]}" -eq 0 ]; then
+            echo "Dependency probe found no pinned apt packages." >&2
+            exit 1
+          fi
+
+          docker build --pull --no-cache -f "${PROBE_DOCKERFILE}" \
+            -t "${PROBE_IMAGE}" .
+          docker run -i --rm --entrypoint bash "${PROBE_IMAGE}" \
+            -s -- "${apt_packages[@]}" > "${apt_versions_path}" <<'EOF'
+          set -euo pipefail
+
+          dpkg-query -W -f='${binary:Package}\t${Version}\n' "$@"
+          EOF
+          base_image="$(awk '$1 == "FROM" { print $2; exit }' "${DOCKERFILE}")"
+          strategy_summary="Render a temporary Dockerfile with apt package pins removed, build it against the configured base image, then read installed versions with dpkg-query."
+
+          non_apt_path="${probe_dir}/non-apt.json"
+          node <<'NODE' > "${non_apt_path}"
+          const fs = require("node:fs");
+
+          const dockerfile = fs.readFileSync(process.env.DOCKERFILE, "utf8");
+          const pins = [];
+          const urls = [];
+
+          for (const line of dockerfile.split(/\r?\n/)) {
+            const argMatch = line.match(/^ARG\s+([A-Za-z_][A-Za-z0-9_]*)=(.+)$/);
+            if (argMatch) {
+              pins.push({
+                kind: "ARG",
+                name: argMatch[1],
+                value: argMatch[2].replace(/^["']|["']$/g, "")
+              });
+            }
+
+            for (const urlMatch of line.matchAll(/https?:\/\/[^"'\s]+/g)) {
+              urls.push(urlMatch[0]);
+            }
+          }
+
+          fs.writeFileSync(
+            process.stdout.fd,
+            JSON.stringify({method: "Dockerfile ARG and URL inventory", pins, urls}, null, 2)
+          );
+          NODE
+
+          jq -n \
+            --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg base_image "${base_image}" \
+            --arg dockerfile "${DOCKERFILE}" \
+            --arg probe_dockerfile "${PROBE_DOCKERFILE}" \
+            --arg strategy_summary "${strategy_summary}" \
+            --slurpfile non_apt "${non_apt_path}" \
+            --rawfile apt_versions "${apt_versions_path}" \
+            '{
+              generated_at: $generated_at,
+              method: "no-pin apt probe",
+              base_image: $base_image,
+              strategy: {
+                summary: $strategy_summary,
+                dockerfile: $dockerfile,
+                probe_dockerfile: $probe_dockerfile
+              },
+              dependencies: {
+                apt: (
+                  $apt_versions
+                  | split("\n")
+                  | map(select(length > 0))
+                  | map(split("\t") | {name: .[0], installed: .[1]})
+                ),
+                non_apt: $non_apt[0]
+              }
+            }' > "${PROBE_REPORT}"
+
+          apt_count="$(jq '.dependencies.apt | length' "${PROBE_REPORT}")"
+          echo "apt_count=${apt_count}" >> "${GITHUB_OUTPUT}"
+          echo "Upgrade probe: wrote ${PROBE_REPORT}."
+
+      - name: Upload dependency report
+        uses: actions/upload-artifact@v7
+        timeout-minutes: 3
+        with:
+          name: docker-dependency-report
+          path: |
+            ${{ needs.config.outputs.report_path }}
+            ${{ needs.config.outputs.probe_dockerfile }}
+
+      - name: Set up Node.js for Copilot CLI
+        uses: actions/setup-node@v6
+        timeout-minutes: 3
+        with:
+          node-version: "22"
+
+      - name: Install Copilot CLI
+        timeout-minutes: 3
+        run: |
+          npm install -g "@github/copilot@latest"
+          echo "Upgrade setup: installed latest stable Copilot CLI"
+
+      - name: Update Dockerfile with Copilot CLI
+        timeout-minutes: 8
+        run: |
+          set -euo pipefail
+
+          test -n "${DOCKERFILE}"
+          test -n "${REPORT_PATH}"
+          test -n "${PROMPT_PARTS}"
+          test -f "${DOCKERFILE}"
+          test -s "${REPORT_PATH}"
+          jq -e '.dependencies.apt and .dependencies.non_apt' \
+            "${REPORT_PATH}" >/dev/null
+
+          if [ -z "${COPILOT_GITHUB_TOKEN:-}" ]; then
+            echo "COPILOT_GITHUB_TOKEN secret is required for non-apt dependency updates." >&2
+            exit 1
+          fi
+
+          prompt_path=".tmp/dependency-upgrade/copilot-prompt.md"
+          mkdir -p "$(dirname "${prompt_path}")"
+          : > "${prompt_path}"
+          for prompt_part in ${PROMPT_PARTS}; do
+            test -s "${prompt_part}"
+            {
+              cat "${prompt_part}"
+              echo
+            } >> "${prompt_path}"
+          done
+          test -s "${prompt_path}"
+
+          mapfile -t copilot_urls < <(
+            jq -r '.dependencies.non_apt.urls[]?' "${REPORT_PATH}" \
+              | sed -E 's#^https?://([^/]+).*$#\1#' \
+              | sort -u
+          )
+          if [ "${#copilot_urls[@]}" -eq 0 ]; then
+            echo "Copilot requires at least one Dockerfile-owned non-apt source URL." >&2
+            exit 1
+          fi
+
+          copilot_args=(
+            --prompt "$(cat "${prompt_path}")"
+            --available-tools "edit,view,grep,glob,web_fetch"
+            --allow-tool "write(${DOCKERFILE})"
+            --secret-env-vars "COPILOT_GITHUB_TOKEN"
+            --no-ask-user
+            --no-auto-update
+            --silent
+          )
+          for copilot_url in "${copilot_urls[@]}"; do
+            copilot_args+=(--allow-url "${copilot_url}")
+          done
+
+          if [ "${UPLOAD_COPILOT_SESSION}" = "true" ]; then
+            copilot_args+=(--share copilot-docker-dependency-session.md)
+          fi
+
+          copilot "${copilot_args[@]}"
+          echo "Upgrade Copilot: completed"
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          COPILOT_AUTO_UPDATE: "false"
+          DOCKERFILE: ${{ needs.config.outputs.dockerfile }}
+          PROMPT_PARTS: ${{ needs.config.outputs.prompt_parts }}
+          REPORT_PATH: ${{ needs.config.outputs.report_path }}
+          UPLOAD_COPILOT_SESSION: ${{ needs.config.outputs.upload_copilot_session }}
+
+      - name: Guard Dockerfile-only changes
+        timeout-minutes: 1
+        run: |
+          set -euo pipefail
+
+          changed_files="$(
+            {
+              git diff --name-only
+              git diff --cached --name-only
+            } | sort -u
+          )"
+          unexpected_changes="$(printf '%s\n' "${changed_files}" \
+            | awk -v dockerfile="${DOCKERFILE}" 'NF && $0 != dockerfile')"
+          if [ -n "${unexpected_changes}" ]; then
+            echo "Upgrade guard: modified files outside ${DOCKERFILE}:" >&2
+            printf '%s\n' "${unexpected_changes}" >&2
+            exit 1
+          fi
+
+          echo "Upgrade guard: tracked changes are limited to ${DOCKERFILE}"
+        env:
+          DOCKERFILE: ${{ needs.config.outputs.dockerfile }}
+
+      - name: Detect changes
+        id: changes
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- "${DOCKERFILE}" \
+            && git diff --cached --quiet -- "${DOCKERFILE}"; then
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+            echo "Upgrade changes: no ${DOCKERFILE} changes"
+          else
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+            {
+              git diff -- "${DOCKERFILE}"
+              git diff --cached -- "${DOCKERFILE}"
+            } > docker-dependency-update.diff
+            changed_lines="$(wc -l < docker-dependency-update.diff | tr -d ' ')"
+            echo "Upgrade changes: ${DOCKERFILE} changed; ${changed_lines} lines"
+          fi
+        env:
+          DOCKERFILE: ${{ needs.config.outputs.dockerfile }}
+
+      - name: Prepare pull request body
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          {
+            echo "## Summary"
+            echo
+            echo "Updates docker-sftp Dockerfile dependency pins."
+            echo
+            echo "## Evidence"
+            echo
+            echo "- Probe report artifact: \`${REPORT_PATH}\`"
+            echo "- Copilot CLI: updated non-apt dependencies"
+            if [ "${UPLOAD_COPILOT_SESSION}" = "true" ]; then
+              echo "- Copilot session artifact: \`copilot-docker-dependency-session.md\`"
+            fi
+            echo "## Diff"
+            echo
+            echo '```diff'
+            sed -n '1,220p' docker-dependency-update.diff
+            echo '```'
+          } > docker-dependency-pr-body.md
+          echo "Upgrade PR body: prepared docker-dependency-pr-body.md"
+        env:
+          REPORT_PATH: ${{ needs.config.outputs.report_path }}
+          UPLOAD_COPILOT_SESSION: ${{ needs.config.outputs.upload_copilot_session }}
+
+      - name: Upload update diff
+        uses: actions/upload-artifact@v7
+        timeout-minutes: 3
+        with:
+          name: docker-dependency-update-diff
+          path: |
+            docker-dependency-update.diff
+          if-no-files-found: ignore
+
+      - name: Upload Copilot session
+        if: >-
+          always() &&
+            needs.config.outputs.upload_copilot_session == 'true'
+        uses: actions/upload-artifact@v7
+        timeout-minutes: 3
+        with:
+          name: docker-dependency-copilot-session
+          path: |
+            copilot-docker-dependency-session.md
+            docker-dependency-update.diff
+          if-no-files-found: ignore
+
+      - name: Create pull request
+        id: create-pr
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v8
+        timeout-minutes: 5
+        with:
+          token: ${{ secrets.DEPENDABOT_REVIEWER_TOKEN || secrets.GH_TOKEN || github.token }}
+          author: udx-github <73100442+udx-github@users.noreply.github.com>
+          committer: udx-github <73100442+udx-github@users.noreply.github.com>
+          commit-message: ${{ needs.config.outputs.commit_message }}
+          title: ${{ needs.config.outputs.pr_title }}
+          body-path: docker-dependency-pr-body.md
+          branch: ${{ needs.config.outputs.update_branch }}
+          add-paths: ${{ needs.config.outputs.dockerfile }}
+          labels: ${{ env.PR_LABELS }}
+          team-reviewers: ${{ env.PR_TEAM_REVIEWER }}
+          draft: false
+          delete-branch: true
+
+      - name: Enable pull request auto-merge
+        if: >-
+          steps.changes.outputs.changed == 'true' &&
+            steps.create-pr.outputs.pull-request-url != '' &&
+            needs.config.outputs.pr_auto_merge == 'true'
+        timeout-minutes: 3
+        run: |
+          set -euo pipefail
+
+          case "${MERGE_METHOD}" in
+            merge|rebase|squash)
+              if gh pr merge "${PR_URL}" --auto "--${MERGE_METHOD}"; then
+                echo "Enabled ${MERGE_METHOD} auto-merge for ${PR_URL}"
+              else
+                echo "Could not enable auto-merge for ${PR_URL}" >&2
+              fi
+              ;;
+            *)
+              echo "Unsupported merge method: ${MERGE_METHOD}" >&2
+              exit 1
+              ;;
+          esac
+        env:
+          GH_TOKEN: ${{ secrets.DEPENDABOT_REVIEWER_TOKEN || secrets.GH_TOKEN || github.token }}
+          MERGE_METHOD: ${{ needs.config.outputs.pr_merge_method }}
+          PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
+
+  report:
+    needs:
+      - config
+      - upgrade
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Write workflow summary
+        if: always()
+        run: |
+          pr_url="${PR_URL:-}"
+          if [ -z "${pr_url}" ]; then
+            pr_url="n/a"
+          fi
+
+          skip_reason="${SKIP_REASON:-}"
+          if [ -z "${skip_reason}" ]; then
+            skip_reason="n/a"
+          fi
+
+          apt_count="${APT_COUNT:-}"
+          if [ -z "${apt_count}" ]; then
+            apt_count="n/a"
+          fi
+
+          changed="${CHANGED:-}"
+          if [ -z "${changed}" ]; then
+            changed="n/a"
+          fi
+
+          {
+            echo "## udx-automation / docker-sftp dependency upgrade"
+            echo
+            echo "- config: ${{ needs.config.result }}"
+            echo "- upgrade: ${{ needs.upgrade.result }}"
+            echo "- report: ${{ job.status }}"
+            echo "- Dockerfile: \`${DOCKERFILE}\`"
+            echo "- branch: \`${UPDATE_BRANCH}\`"
+            echo "- should run: \`${SHOULD_RUN}\`"
+            echo "- report artifact: \`${REPORT_PATH}\`"
+            echo "- apt packages: \`${apt_count}\`"
+            echo "- Dockerfile changed: \`${changed}\`"
+            echo "- PR: ${pr_url}"
+            echo "- skip: \`${skip_reason}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+        env:
+          APT_COUNT: ${{ needs.upgrade.outputs.apt_count }}
+          CHANGED: ${{ needs.upgrade.outputs.changed }}
+          DOCKERFILE: ${{ needs.config.outputs.dockerfile }}
+          PR_URL: ${{ needs.upgrade.outputs.pr_url }}
+          REPORT_PATH: ${{ needs.config.outputs.report_path }}
+          SKIP_REASON: ${{ needs.config.outputs.skip_reason }}
+          SHOULD_RUN: ${{ needs.config.outputs.should_run }}
+          UPDATE_BRANCH: ${{ needs.config.outputs.update_branch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM usabilitydynamics/udx-worker-nodejs:0.35.0
 
-ENV KUBECTL_VERSION=1.36.2 \
+ARG KUBECTL_VERSION=1.36.2
+
+ENV KUBECTL_VERSION=${KUBECTL_VERSION} \
     NODE_ENV=production \
     APP_HOME=/opt/sources/rabbitci/rabbit-ssh
 

--- a/ci/prompts/docker-dependency-apt.md
+++ b/ci/prompts/docker-dependency-apt.md
@@ -1,0 +1,6 @@
+Apt dependency rules:
+- The dependency report resolves apt package versions for the configured Ubuntu base image using a no-pin apt probe.
+- The no-pin apt probe is authoritative for apt package updates.
+- For apt packages, update Dockerfile pins only from `dependencies.apt[].installed` in the dependency report.
+- Do not use apt websites, package search pages, or guessed versions for apt pins.
+- If an apt package from Dockerfile is missing from the report, leave that package unchanged and explain it in the changelog.

--- a/ci/prompts/docker-dependency-guardrails.md
+++ b/ci/prompts/docker-dependency-guardrails.md
@@ -1,0 +1,18 @@
+You are updating Dockerfile dependency pins for this repository.
+
+Inputs:
+- Dockerfile: `Dockerfile`
+- Dependency report: `docker-dependency-report.json`
+
+Hard boundaries:
+- This is an edit-only dependency update task.
+- Read both input files before editing.
+- Edit only Dockerfile dependency pins and ARG/ENV values.
+- Keep apt package pins inline in their `apt-get install` command. Use Dockerfile `ARG`s only for non-apt dependency versions.
+- Do not edit workflow files, docs, tests, or application code.
+- Do not validate, build, test, run the container pipeline, inspect GitHub Actions runs, wait for workflows, create pull requests, commit, push, or request reviews.
+- Do not run `docker`, `make`, test commands, CI commands, `gh run`, `gh workflow`, `gh pr`, `git commit`, `git push`, or any command that waits on external workflow state.
+- Do not use vulnerability scanners or security reports to decide whether a dependency should be updated.
+- Apt package updates must be backed by the dependency report.
+- Non-apt package updates must be backed by the dependency report inventory plus clear upstream version evidence.
+- If an update is not backed by the required evidence, leave it unchanged and mention why.

--- a/ci/prompts/docker-dependency-nonapt.md
+++ b/ci/prompts/docker-dependency-nonapt.md
@@ -1,0 +1,9 @@
+Non-apt dependency rules:
+- Use `dependencies.non_apt.pins` and `dependencies.non_apt.urls` from the dependency report as the starting inventory of Dockerfile-owned non-apt candidates.
+- Treat Dockerfile `ARG`s as the complete inventory of versioned non-apt dependencies. Do not add apt package pins to that inventory.
+- For every non-apt `ARG`, resolve the authoritative source dynamically from the Dockerfile usage: an image registry/release source for a base image, or the official release source for a downloaded artifact.
+- Update only to a newer stable version that is compatible with the existing Dockerfile contract.
+- Preserve existing checksum verification and artifact-selection logic when updating a downloaded tool.
+- Include the upstream source URL for every non-apt update in the changelog.
+- Leave pins unchanged when the upstream source cannot be identified, cannot be checked, is ambiguous, or does not clearly show a newer stable release/version.
+- Keep dynamically installed dependencies unpinned unless Dockerfile already pins them; mention them in the changelog only.

--- a/ci/prompts/docker-dependency-output.md
+++ b/ci/prompts/docker-dependency-output.md
@@ -1,0 +1,21 @@
+Output:
+- Print a changelog using this template:
+
+```text
+Docker dependency changelog
+
+Updated:
+- <dependency>: <old version> -> <new version> (<source>)
+
+Unchanged:
+- <dependency>: <version> (<reason>)
+
+Observed but not pinned:
+- <dependency>: <observed version> (<reason>)
+
+Notes:
+- <short note, or "None">
+```
+
+- Omit empty sections except `Notes`.
+- Do not claim build, test, scanner, or CI validation.


### PR DESCRIPTION
## Summary
- Add a scheduled and manually dispatchable Docker dependency updater that opens one guarded PR at a time.
- Generate a no-pin apt package report and use Copilot CLI only for Dockerfile dependency-pin updates.
- Expose the Worker base image, kubectl, and pinned apt package versions as Docker build arguments.

## Scope
- Changed: Dockerfile dependency configuration, updater workflow, updater prompts, and generated Rabbit context.
- Not changed: runtime dependency versions or automatic merging of update PRs.

## Validation
- npm test
- Workflow YAML and generated no-pin probe validation
- Full Docker build was not run because the local Docker daemon is unavailable.