### PR TITLE
fix(ci): allow Copilot patch updates

### DIFF
--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -365,7 +365,7 @@ jobs:
 
           copilot_args=(
             --prompt "$(cat "${prompt_path}")"
-            --available-tools "edit,view,grep,glob,web_fetch"
+            --available-tools "apply_patch,edit,view,grep,glob,web_fetch"
             --allow-tool "write(${DOCKERFILE})"
             --secret-env-vars "COPILOT_GITHUB_TOKEN"
             --no-ask-user
@@ -460,6 +460,7 @@ jobs:
           UPLOAD_COPILOT_SESSION: ${{ needs.config.outputs.upload_copilot_session }}
 
       - name: Upload update diff
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/upload-artifact@v7
         timeout-minutes: 3
         with:


### PR DESCRIPTION
## Summary

- Allow Copilot CLI's apply_patch tool, restricted to Dockerfile writes.
- Skip the diff artifact when an update run makes no Dockerfile changes.

## Impact

Kubectl and other detected Docker dependency updates can now be applied and proposed as pull requests.