### PR TITLE
fix(ci): version Docker dependency updates

### DIFF
--- a/.github/workflows/_dependabot-actions-review.yml
+++ b/.github/workflows/_dependabot-actions-review.yml
@@ -1,5 +1,5 @@
 ---
-name: _udx-automation / docker ops dependency review
+name: udx-automation / reviewer
 
 "on":
   schedule:
@@ -353,7 +353,7 @@ jobs:
           REPORT_PATH: ${{ env.REPORT_PATH }}
         run: |
           {
-            echo "## _udx-automation / docker ops dependency review"
+            echo "## udx-automation / reviewer"
             echo
             echo "- Dependabot Docker Ops PRs: \`${PR_COUNT:-0}\`"
             echo "- Dry run: \`${DRY_RUN}\`"

--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -413,7 +413,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          npm version patch --no-git-tag-version --ignore-scripts
+          npm version patch --no-git-tag-version --ignore-scripts --force
           version="$(node -p "require('./package.json').version")"
           echo "Upgrade version: bumped package version to ${version}"
 

--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -1,5 +1,5 @@
 ---
-name: udx-automation / docker-sftp dependency upgrade
+name: udx-automation / updater
 
 "on":
   schedule:
@@ -592,7 +592,7 @@ jobs:
           fi
 
           {
-            echo "## udx-automation / docker-sftp dependency upgrade"
+            echo "## udx-automation / updater"
             echo
             echo "- config: ${{ needs.config.result }}"
             echo "- upgrade: ${{ needs.upgrade.result }}"

--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -25,7 +25,7 @@ env:
     dependencies
   PR_AUTO_MERGE: "false"
   PR_MERGE_METHOD: squash
-  COMMIT_MESSAGE: "chore(deps): update Docker dependency pins"
+  COMMIT_MESSAGE: "chore(deps): update Docker dependencies and version"
   UPLOAD_COPILOT_SESSION: "false"
   COPILOT_PROMPT_PARTS: >-
     ci/prompts/docker-dependency-guardrails.md
@@ -390,7 +390,34 @@ jobs:
           REPORT_PATH: ${{ needs.config.outputs.report_path }}
           UPLOAD_COPILOT_SESSION: ${{ needs.config.outputs.upload_copilot_session }}
 
-      - name: Guard Dockerfile-only changes
+      - name: Detect Dockerfile changes
+        id: dockerfile-changes
+        timeout-minutes: 1
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- "${DOCKERFILE}" \
+            && git diff --cached --quiet -- "${DOCKERFILE}"; then
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+            echo "Upgrade changes: no ${DOCKERFILE} changes"
+          else
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+            echo "Upgrade changes: ${DOCKERFILE} changed"
+          fi
+        env:
+          DOCKERFILE: ${{ needs.config.outputs.dockerfile }}
+
+      - name: Bump package patch version
+        if: steps.dockerfile-changes.outputs.changed == 'true'
+        timeout-minutes: 1
+        run: |
+          set -euo pipefail
+
+          npm version patch --no-git-tag-version --ignore-scripts
+          version="$(node -p "require('./package.json').version")"
+          echo "Upgrade version: bumped package version to ${version}"
+
+      - name: Guard dependency update changes
         timeout-minutes: 1
         run: |
           set -euo pipefail
@@ -402,14 +429,15 @@ jobs:
             } | sort -u
           )"
           unexpected_changes="$(printf '%s\n' "${changed_files}" \
-            | awk -v dockerfile="${DOCKERFILE}" 'NF && $0 != dockerfile')"
+            | awk -v dockerfile="${DOCKERFILE}" \
+                'NF && $0 != dockerfile && $0 != "package.json" && $0 != "package-lock.json"')"
           if [ -n "${unexpected_changes}" ]; then
-            echo "Upgrade guard: modified files outside ${DOCKERFILE}:" >&2
+            echo "Upgrade guard: modified files outside the dependency update allowlist:" >&2
             printf '%s\n' "${unexpected_changes}" >&2
             exit 1
           fi
 
-          echo "Upgrade guard: tracked changes are limited to ${DOCKERFILE}"
+          echo "Upgrade guard: tracked changes are limited to ${DOCKERFILE}, package.json, and package-lock.json"
         env:
           DOCKERFILE: ${{ needs.config.outputs.dockerfile }}
 
@@ -417,18 +445,18 @@ jobs:
         id: changes
         run: |
           set -euo pipefail
-          if git diff --quiet -- "${DOCKERFILE}" \
-            && git diff --cached --quiet -- "${DOCKERFILE}"; then
+          if git diff --quiet -- "${DOCKERFILE}" package.json package-lock.json \
+            && git diff --cached --quiet -- "${DOCKERFILE}" package.json package-lock.json; then
             echo "changed=false" >> "${GITHUB_OUTPUT}"
-            echo "Upgrade changes: no ${DOCKERFILE} changes"
+            echo "Upgrade changes: no dependency update changes"
           else
             echo "changed=true" >> "${GITHUB_OUTPUT}"
             {
-              git diff -- "${DOCKERFILE}"
-              git diff --cached -- "${DOCKERFILE}"
+              git diff -- "${DOCKERFILE}" package.json package-lock.json
+              git diff --cached -- "${DOCKERFILE}" package.json package-lock.json
             } > docker-dependency-update.diff
             changed_lines="$(wc -l < docker-dependency-update.diff | tr -d ' ')"
-            echo "Upgrade changes: ${DOCKERFILE} changed; ${changed_lines} lines"
+            echo "Upgrade changes: dependency pins and package version changed; ${changed_lines} lines"
           fi
         env:
           DOCKERFILE: ${{ needs.config.outputs.dockerfile }}
@@ -439,7 +467,7 @@ jobs:
           {
             echo "## Summary"
             echo
-            echo "Updates docker-sftp Dockerfile dependency pins."
+            echo "Updates docker-sftp Dockerfile dependency pins and patches the package version."
             echo
             echo "## Evidence"
             echo
@@ -495,7 +523,10 @@ jobs:
           title: ${{ needs.config.outputs.pr_title }}
           body-path: docker-dependency-pr-body.md
           branch: ${{ needs.config.outputs.update_branch }}
-          add-paths: ${{ needs.config.outputs.dockerfile }}
+          add-paths: |
+            ${{ needs.config.outputs.dockerfile }}
+            package.json
+            package-lock.json
           labels: ${{ env.PR_LABELS }}
           team-reviewers: ${{ env.PR_TEAM_REVIEWER }}
           draft: false

--- a/.rabbit/README.md
+++ b/.rabbit/README.md
@@ -33,6 +33,16 @@ tenant-specific Rabbit lifecycle manifests or environment config.
    platform. Image-level defaults and deployment examples belong in the
    maintained Kubernetes manifests and docs.
 
+## Dependency Maintenance Automation
+
+- `udx-automation / updater` checks Dockerfile dependency pins on its scheduled
+  run. Copilot is limited to Dockerfile edits; when a pin changes, the workflow
+  independently bumps the npm patch version in `package.json` and
+  `package-lock.json` before opening its pull request.
+- `udx-automation / reviewer` reviews eligible Dependabot Docker, npm, and
+  GitHub Actions dependency pull requests according to its configured safety
+  checks.
+
 ## Docker Hub Release Configuration
 
 The Docker operations workflow publishes only from `master` when these GitHub

--- a/.rabbit/README.md
+++ b/.rabbit/README.md
@@ -36,9 +36,13 @@ tenant-specific Rabbit lifecycle manifests or environment config.
 ## Dependency Maintenance Automation
 
 - `udx-automation / updater` checks Dockerfile dependency pins on its scheduled
-  run. Copilot is limited to Dockerfile edits; when a pin changes, the workflow
-  independently bumps the npm patch version in `package.json` and
-  `package-lock.json` before opening its pull request.
+  run. Copilot is limited to Dockerfile edits. When a pin changes, the workflow
+  opens a pull request with the Dockerfile change and the next npm patch version
+  in `package.json` and `package-lock.json`. This prepares a release; it does
+  not publish an image.
+- Merging that pull request to `master` enters the normal Docker Operations
+  release path, which builds and publishes the image. Runs from other branches
+  build and scan without publishing a release.
 - `udx-automation / reviewer` reviews eligible Dependabot Docker, npm, and
   GitHub Actions dependency pull requests according to its configured safety
   checks.


### PR DESCRIPTION
## Summary

- Allow the dependency updater's Copilot step to apply its Dockerfile edits.
- Bump the npm patch version and lockfile whenever a Docker dependency pin changes.
- Simplify automation workflow names and document the updater contract.

## Scope

- Changed: dependency updater and reviewer workflow metadata, guards, and generated PR contents.
- Not changed: application runtime behavior or current Docker dependency pins.

## Validation

- Workflow YAML parses successfully.
- Verified the patch bump keeps package and lockfile versions aligned.