### PR TITLE
chore(deps): docker dependency upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM usabilitydynamics/udx-worker-nodejs:0.35.0
 
-ARG KUBECTL_VERSION=1.36.2
+ARG KUBECTL_VERSION=1.36.3
 
 ENV KUBECTL_VERSION=${KUBECTL_VERSION} \
     NODE_ENV=production \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docker-sftp",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docker-sftp",
-      "version": "0.14.4",
+      "version": "0.14.5",
       "license": "ISC",
       "dependencies": {
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-sftp",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "SSH tunnels to Kubernetes containers",
   "main": "lib/server.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Updates docker-sftp Dockerfile dependency pins and patches the package version.

## Evidence

- Probe report artifact: `docker-dependency-report.json`
- Copilot CLI: updated non-apt dependencies
## Diff

```diff
diff --git a/Dockerfile b/Dockerfile
index 46c6faf..addeb40 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM usabilitydynamics/udx-worker-nodejs:0.35.0
 
-ARG KUBECTL_VERSION=1.36.2
+ARG KUBECTL_VERSION=1.36.3
 
 ENV KUBECTL_VERSION=${KUBECTL_VERSION} \
     NODE_ENV=production \
diff --git a/package-lock.json b/package-lock.json
index 3936ff5..9cf0072 100644
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docker-sftp",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docker-sftp",
-      "version": "0.14.4",
+      "version": "0.14.5",
       "license": "ISC",
       "dependencies": {
         "async": "^3.2.6",
diff --git a/package.json b/package.json
index c96f1b6..ebfa8ad 100644
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-sftp",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "SSH tunnels to Kubernetes containers",
   "main": "lib/server.js",
   "scripts": {
```
