### PR TITLE
fix(ci): enable scheduled Dependabot merges

### DIFF
--- a/.github/workflows/_dependabot-actions-review.yml
+++ b/.github/workflows/_dependabot-actions-review.yml
@@ -93,7 +93,7 @@ jobs:
         if: steps.inventory.outputs.pr_count != '0'
         env:
           AUTOMATION_GITHUB_TOKEN: ${{ secrets.DEPENDABOT_REVIEWER_TOKEN || github.token }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'true' }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
           GH_TOKEN: ${{ secrets.DEPENDABOT_REVIEWER_TOKEN || github.token }}
           HUMAN_REVIEWER: ${{ env.HUMAN_REVIEWER }}
           MERGE_METHOD: ${{ env.MERGE_METHOD }}
@@ -349,7 +349,7 @@ jobs:
         env:
           AUTOMATION_IDENTITY: ${{ secrets.DEPENDABOT_REVIEWER_TOKEN && 'DEPENDABOT_REVIEWER_TOKEN' || 'GITHUB_TOKEN fallback' }}
           PR_COUNT: ${{ steps.inventory.outputs.pr_count }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'true' }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
           REPORT_PATH: ${{ env.REPORT_PATH }}
         run: |
           {

--- a/.rabbit/README.md
+++ b/.rabbit/README.md
@@ -45,7 +45,8 @@ tenant-specific Rabbit lifecycle manifests or environment config.
   build and scan without publishing a release.
 - `udx-automation / reviewer` reviews eligible Dependabot Docker, npm, and
   GitHub Actions dependency pull requests according to its configured safety
-  checks.
+  checks. Scheduled runs can approve and merge safe PRs; manually dispatched
+  runs default to dry-run mode unless explicitly changed.
 
 ## Docker Hub Release Configuration
 


### PR DESCRIPTION
## Summary

- Enable live review and merge attempts for safe Dependabot PRs on the scheduled reviewer run.
- Keep manually dispatched reviewer runs dry by default.
- Document the two execution modes.

## Validation

- Parsed `.github/workflows/_dependabot-actions-review.yml` with Ruby's YAML parser.
- Ran `git diff --check`.

## Related follow-up

`kubectl` remains pinned to the latest available official Kubernetes 1.36 patch release. The tracked `x/net` CVE requires an upstream Kubernetes release containing `x/net` 0.55.0 or later; the current 1.36 release branch remains at 0.49.0, so no unsupported pin is included here.
