### PR TITLE
fix(ci): version image dependency updates

### DIFF
--- a/.github/workflows/_dependabot-actions-review.yml
+++ b/.github/workflows/_dependabot-actions-review.yml
@@ -1,5 +1,5 @@
 ---
-name: udx-automation / reviewer
+name: rabbit / reviewer
 
 "on":
   schedule:
@@ -218,6 +218,18 @@ jobs:
             sed 's/\\/\\\\/g; s/|/\\|/g'
           }
 
+          changes_image_input() {
+            local details_path="$1"
+
+            jq -e '
+              any(.files[]?;
+                .path == "Dockerfile" or
+                .path == "package.json" or
+                .path == "package-lock.json"
+              )
+            ' "${details_path}" >/dev/null
+          }
+
           classify_status() {
             local details_path="$1"
 
@@ -262,6 +274,11 @@ jobs:
             url="$(jq -r '.url' "${details_path}")"
             changed_files="$(jq -r '[.files[].path] | join(", ")' "${details_path}")"
             result="$(classify_status "${details_path}")"
+
+            if changes_image_input "${details_path}"; then
+              result="needs release|Image-input dependency changes require a single release PR with the next npm minor version before merge"
+            fi
+
             decision="${result%%|*}"
             reason="${result#*|}"
             report_reason="$(printf '%s' "${reason}" | markdown_escape)"
@@ -353,7 +370,7 @@ jobs:
           REPORT_PATH: ${{ env.REPORT_PATH }}
         run: |
           {
-            echo "## udx-automation / reviewer"
+            echo "## rabbit / reviewer"
             echo
             echo "- Dependabot Docker Ops PRs: \`${PR_COUNT:-0}\`"
             echo "- Dry run: \`${DRY_RUN}\`"

--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -1,5 +1,5 @@
 ---
-name: udx-automation / updater
+name: rabbit / updater
 
 "on":
   schedule:
@@ -407,13 +407,13 @@ jobs:
         env:
           DOCKERFILE: ${{ needs.config.outputs.dockerfile }}
 
-      - name: Bump package patch version
+      - name: Bump package minor version
         if: steps.dockerfile-changes.outputs.changed == 'true'
         timeout-minutes: 1
         run: |
           set -euo pipefail
 
-          npm version patch --no-git-tag-version --ignore-scripts --force
+          npm version minor --no-git-tag-version --ignore-scripts --force
           version="$(node -p "require('./package.json').version")"
           echo "Upgrade version: bumped package version to ${version}"
 
@@ -467,7 +467,7 @@ jobs:
           {
             echo "## Summary"
             echo
-            echo "Updates docker-sftp Dockerfile dependency pins and patches the package version."
+            echo "Updates docker-sftp Dockerfile dependency pins and bumps the package minor version."
             echo
             echo "## Evidence"
             echo
@@ -592,7 +592,7 @@ jobs:
           fi
 
           {
-            echo "## udx-automation / updater"
+            echo "## rabbit / updater"
             echo
             echo "- config: ${{ needs.config.result }}"
             echo "- upgrade: ${{ needs.upgrade.result }}"

--- a/.rabbit/README.md
+++ b/.rabbit/README.md
@@ -35,18 +35,20 @@ tenant-specific Rabbit lifecycle manifests or environment config.
 
 ## Dependency Maintenance Automation
 
-- `udx-automation / updater` checks Dockerfile dependency pins on its scheduled
+- `rabbit / updater` checks Dockerfile dependency pins on its scheduled
   run. Copilot is limited to Dockerfile edits. When a pin changes, the workflow
-  opens a pull request with the Dockerfile change and the next npm patch version
+  opens a pull request with the Dockerfile change and the next npm minor version
   in `package.json` and `package-lock.json`. This prepares a release; it does
   not publish an image.
 - Merging that pull request to `master` enters the normal Docker Operations
   release path, which builds and publishes the image. Runs from other branches
   build and scan without publishing a release.
-- `udx-automation / reviewer` reviews eligible Dependabot Docker, npm, and
+- `rabbit / reviewer` reviews eligible Dependabot Docker, npm, and
   GitHub Actions dependency pull requests according to its configured safety
   checks. Scheduled runs can approve and merge safe PRs; manually dispatched
-  runs default to dry-run mode unless explicitly changed.
+  runs default to dry-run mode unless explicitly changed. It does not merge a
+  change to `Dockerfile`, `package.json`, or `package-lock.json`: consolidate
+  image-input updates into one release PR with the next npm minor version.
 
 ## Docker Hub Release Configuration
 


### PR DESCRIPTION
## Summary

- Rename the dependency workflows to `rabbit / reviewer` and `rabbit / updater`.
- Keep the reviewer read-only: it does not merge Dependabot changes to `Dockerfile`, `package.json`, or `package-lock.json`.
- Require those image-input updates to be consolidated in one release PR with the next npm minor version.
- Align the existing Rabbit Docker dependency updater with the minor-version policy.

## Validation

- Parsed both workflow YAML files.
- Parsed the `Review Dependabot PRs` and `Bump package minor version` shell steps with `bash -n`.
- Verified the image-input predicate against Docker PR #192, npm PR #195, and Actions-only PR #193.
- Ran a dry review from this branch: image-input PRs were release-gated and the Actions-only PR remained eligible.
- Ran `git diff --check`.
